### PR TITLE
Made it so world does not close out in end.

### DIFF
--- a/karel_the_robot/src/karel_the_robot.py
+++ b/karel_the_robot/src/karel_the_robot.py
@@ -1010,7 +1010,7 @@ See [Using Worlds within Code](#using-worlds-within-code) for more detailed info
             pygame.display.flip()
         print("[World] Saving screenshot...")
         pygame.image.save(self.__screen, "final_world_status.jpg")
-        print("[World] Program finished...)
+        print("[World] Program finished...")
         running = True
         while running:
             for event in pygame.event.get():

--- a/karel_the_robot/src/karel_the_robot.py
+++ b/karel_the_robot/src/karel_the_robot.py
@@ -1010,8 +1010,12 @@ See [Using Worlds within Code](#using-worlds-within-code) for more detailed info
             pygame.display.flip()
         print("[World] Saving screenshot...")
         pygame.image.save(self.__screen, "final_world_status.jpg")
-        print("[World] Quitting...")
-        pygame.quit()
+        print("[World] Program finished...)
+        running = True
+        while running:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
 
 # TODO: add dialogue for all robot moves
 # TODO: add more error messages


### PR DESCRIPTION
World no longer closes at end of program. Waits until window's X is clicked.  I left in the screenshot, however I would recommend removing it as a user can call that method if they wish.  I am thinking you added it to the end of every program because the window would close.